### PR TITLE
Improve cashier product filtering

### DIFF
--- a/src/pages/cajero/Context.js
+++ b/src/pages/cajero/Context.js
@@ -1,4 +1,5 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useEffect } from 'react';
+import { getData } from '../../apiService';
 
 // Creamos el contexto
 export const CajeroContext = createContext();
@@ -6,6 +7,26 @@ export const CajeroContext = createContext();
 // Proveedor del contexto
 export const CajeroProvider = ({ children }) => {
   const [items, setItems] = useState([]);
+  const [productos, setProductos] = useState([]);
+
+  const bodegaActual = new URLSearchParams(window.location.search).get('bodega') || 'Principal';
+
+  useEffect(() => {
+    const fetchProductos = async () => {
+      try {
+        const res = await getData('inventario/skus-con-bodegas/?page_size=1000');
+        const all = res.data.results || [];
+        const filtrados = all.filter(sku =>
+          sku.bodegas?.some(b => b.nombre_bodega?.toLowerCase() === bodegaActual.toLowerCase())
+        );
+        setProductos(filtrados);
+      } catch (err) {
+        console.error('Error al cargar productos:', err);
+      }
+    };
+
+    fetchProductos();
+  }, [bodegaActual]);
 
   // Agregar producto
   const addItem = (item) => {
@@ -18,7 +39,7 @@ export const CajeroProvider = ({ children }) => {
   };
 
   return (
-    <CajeroContext.Provider value={{ items, addItem, clearItems }}>
+    <CajeroContext.Provider value={{ items, productos, addItem, clearItems }}>
       {children}
     </CajeroContext.Provider>
   );

--- a/src/pages/cajero/Form.js
+++ b/src/pages/cajero/Form.js
@@ -6,7 +6,7 @@ import { FaPlus, FaBroom, FaCashRegister, FaSignOutAlt } from 'react-icons/fa';
 
 const CajeroForm = () => {
     const { register, handleSubmit, reset } = useForm();
-    const { items, addItem, clearItems } = useContext(CajeroContext);
+    const { items, productos, addItem, clearItems } = useContext(CajeroContext);
 
     // 🔄 Recargar automáticamente al entrar (solo cuando no quieres tocar el router)
     useEffect(() => {
@@ -20,6 +20,11 @@ const CajeroForm = () => {
 
 
     const onSubmit = (data) => {
+        const existe = productos.find(p => p.nombre === data.producto);
+        if (!existe) {
+            alert('El producto no pertenece a esta bodega');
+            return;
+        }
         addItem(data);
         reset();
     };
@@ -39,8 +44,14 @@ const CajeroForm = () => {
                                     size="md"
                                     type="text"
                                     placeholder="Nombre del producto"
+                                    list="lista-productos"
                                     {...register('producto', { required: true })}
                                 />
+                                <datalist id="lista-productos">
+                                    {productos.map(p => (
+                                        <option key={p.id} value={p.nombre} />
+                                    ))}
+                                </datalist>
                             </Col>
 
                             <Col md={3}>


### PR DESCRIPTION
## Summary
- load store-specific SKUs when opening the cashier page
- show filtered product suggestions with `<datalist>`
- prevent adding products not belonging to the current store

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6875f618bcc8833194aa9c338fb29a07