### PR TITLE
Improve cashier product filtering

### DIFF
--- a/src/pages/cajero/Context.js
+++ b/src/pages/cajero/Context.js
@@ -1,4 +1,5 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useEffect } from 'react';
+import { getData } from '../../apiService';
 
 // Creamos el contexto
 export const CajeroContext = createContext();
@@ -6,6 +7,56 @@ export const CajeroContext = createContext();
 // Proveedor del contexto
 export const CajeroProvider = ({ children }) => {
   const [items, setItems] = useState([]);
+  const [productos, setProductos] = useState([]);
+  const [bodegas, setBodegas] = useState([]);
+
+  const initialBodega = new URLSearchParams(window.location.search).get('bodega') ||
+    localStorage.getItem('bodegaPredeterminada') || '';
+  const [bodegaActual, setBodegaActual] = useState(initialBodega);
+
+  useEffect(() => {
+    const fetchBodegas = async () => {
+      try {
+        const res = await getData('inventario/bodegas/?page_size=1000');
+        const lista = res.data.results || [];
+        setBodegas(lista);
+        if (!initialBodega && lista.length > 0) {
+          setBodegaActual(lista[0].nombre);
+        }
+      } catch (err) {
+        console.error('Error al cargar bodegas:', err);
+      }
+    };
+    fetchBodegas();
+  }, []);
+
+  useEffect(() => {
+    if (!bodegaActual) {
+      setProductos([]);
+      return;
+    }
+    const fetchProductos = async () => {
+      try {
+        const res = await getData('inventario/skus-con-bodegas/?page_size=1000');
+        const all = res.data.results || [];
+        const filtrados = all.filter(sku =>
+          sku.bodegas?.some(b => b.nombre_bodega?.toLowerCase() === bodegaActual.toLowerCase())
+        );
+        setProductos(filtrados);
+      } catch (err) {
+        console.error('Error al cargar productos:', err);
+      }
+    };
+
+    fetchProductos();
+  }, [bodegaActual]);
+
+  const changeBodega = (nombre, recordar) => {
+    setBodegaActual(nombre);
+    if (recordar) {
+      localStorage.setItem('bodegaPredeterminada', nombre);
+    }
+  };
 
   // Agregar producto
   const addItem = (item) => {
@@ -18,7 +69,17 @@ export const CajeroProvider = ({ children }) => {
   };
 
   return (
-    <CajeroContext.Provider value={{ items, addItem, clearItems }}>
+    <CajeroContext.Provider
+      value={{
+        items,
+        productos,
+        bodegas,
+        bodegaActual,
+        changeBodega,
+        addItem,
+        clearItems,
+      }}
+    >
       {children}
     </CajeroContext.Provider>
   );

--- a/src/pages/cajero/Context.js
+++ b/src/pages/cajero/Context.js
@@ -53,8 +53,10 @@ export const CajeroProvider = ({ children }) => {
 
   const changeBodega = (nombre, recordar) => {
     setBodegaActual(nombre);
-    if (recordar) {
+    if (recordar && nombre) {
       localStorage.setItem('bodegaPredeterminada', nombre);
+    } else if (!recordar || !nombre) {
+      localStorage.removeItem('bodegaPredeterminada');
     }
   };
 

--- a/src/pages/cajero/Form.js
+++ b/src/pages/cajero/Form.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Form, Button, Table, Row, Col, Card, Container } from 'react-bootstrap';
 import { CajeroContext } from './Context';
@@ -6,7 +6,8 @@ import { FaPlus, FaBroom, FaCashRegister, FaSignOutAlt } from 'react-icons/fa';
 
 const CajeroForm = () => {
     const { register, handleSubmit, reset } = useForm();
-    const { items, addItem, clearItems } = useContext(CajeroContext);
+    const { items, productos, bodegas, bodegaActual, changeBodega, addItem, clearItems } = useContext(CajeroContext);
+    const [recordar, setRecordar] = useState(!!localStorage.getItem('bodegaPredeterminada'));
 
     // 🔄 Recargar automáticamente al entrar (solo cuando no quieres tocar el router)
     useEffect(() => {
@@ -20,6 +21,11 @@ const CajeroForm = () => {
 
 
     const onSubmit = (data) => {
+        const existe = productos.find(p => p.nombre === data.producto);
+        if (!existe) {
+            alert('El producto no pertenece a esta bodega');
+            return;
+        }
         addItem(data);
         reset();
     };
@@ -32,6 +38,37 @@ const CajeroForm = () => {
                 </Card.Header>
                 <Card.Body>
                     <Form onSubmit={handleSubmit(onSubmit)}>
+                        <Row className="mb-3">
+                            <Col md={6}>
+                                <Form.Label>Tienda</Form.Label>
+                                <Form.Control
+                                    as="select"
+                                    value={bodegaActual}
+                                    onChange={e => changeBodega(e.target.value, recordar)}
+                                >
+                                    <option value="">Seleccione una tienda</option>
+                                    {bodegas.map(b => (
+                                        <option key={b.id} value={b.nombre}>{b.nombre}</option>
+                                    ))}
+                                </Form.Control>
+                            </Col>
+                            <Col md={6} className="mt-4">
+                                <Form.Check
+                                    type="checkbox"
+                                    label="Recordar como predeterminada"
+                                    checked={recordar}
+                                    onChange={e => {
+                                        const val = e.target.checked;
+                                        setRecordar(val);
+                                        if (!val) {
+                                            localStorage.removeItem('bodegaPredeterminada');
+                                        } else if (bodegaActual) {
+                                            localStorage.setItem('bodegaPredeterminada', bodegaActual);
+                                        }
+                                    }}
+                                />
+                            </Col>
+                        </Row>
                         <Row className="mb-4 align-items-end">
                             <Col md={5}>
                                 <Form.Label>Producto</Form.Label>
@@ -39,8 +76,14 @@ const CajeroForm = () => {
                                     size="md"
                                     type="text"
                                     placeholder="Nombre del producto"
+                                    list="lista-productos"
                                     {...register('producto', { required: true })}
                                 />
+                                <datalist id="lista-productos">
+                                    {productos.map(p => (
+                                        <option key={p.id} value={p.nombre} />
+                                    ))}
+                                </datalist>
                             </Col>
 
                             <Col md={3}>

--- a/src/pages/cajero/Form.js
+++ b/src/pages/cajero/Form.js
@@ -21,12 +21,12 @@ const CajeroForm = () => {
 
 
     const onSubmit = (data) => {
-        const existe = productos.find(p => p.nombre === data.producto);
+        const existe = productos.find(p => p.nombre.toLowerCase() === data.producto.toLowerCase());
         if (!existe) {
             alert('El producto no pertenece a esta bodega');
             return;
         }
-        addItem(data);
+        addItem({ ...data, producto: existe.nombre });
         reset();
     };
 
@@ -80,9 +80,12 @@ const CajeroForm = () => {
                                     {...register('producto', { required: true })}
                                 />
                                 <datalist id="lista-productos">
-                                    {productos.map(p => (
-                                        <option key={p.id} value={p.nombre} />
-                                    ))}
+                                    {productos
+                                        .slice()
+                                        .sort((a, b) => a.nombre.localeCompare(b.nombre))
+                                        .map(p => (
+                                            <option key={p.id} value={p.nombre} />
+                                        ))}
                                 </datalist>
                             </Col>
 


### PR DESCRIPTION
## Summary
- add list of stores and persist preferred store
- allow choosing store and remember selection
- filter product autocomplete by chosen store

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6875f618bcc8833194aa9c338fb29a07