### PR TITLE
Implement caja filter and default selection

### DIFF
--- a/src/pages/admisiones/caja/Form.js
+++ b/src/pages/admisiones/caja/Form.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Row,
   Col,
@@ -10,8 +10,52 @@ import { useForm } from 'react-hook-form';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
 
 const FormularioAdmision = () => {
-  const { register, handleSubmit } = useForm();
+  const defaultCaja = localStorage.getItem('defaultCaja') || '';
+  const defaultBodega = localStorage.getItem('defaultBodega') || '';
+  const { register, handleSubmit, watch } = useForm({
+    defaultValues: {
+      caja: defaultCaja,
+      bodega: defaultBodega
+    }
+  });
   const [showPassword, setShowPassword] = useState(false);
+  const [filtroCaja, setFiltroCaja] = useState('');
+  const [filtroBodega, setFiltroBodega] = useState('');
+
+  const cajas = [
+    { value: 'admisiones', label: 'Caja Admisiones' },
+    { value: 'farmacia', label: 'Caja Farmacia' },
+    { value: 'consulta', label: 'Caja Consulta Externa' }
+  ];
+
+  const bodegas = [
+    { value: 'central', label: 'Bodega Central' },
+    { value: 'norte', label: 'Bodega Norte' },
+    { value: 'sur', label: 'Bodega Sur' }
+  ];
+
+  const cajasFiltradas = cajas.filter(caja =>
+    caja.label.toLowerCase().includes(filtroCaja.toLowerCase())
+  );
+
+  const bodegasFiltradas = bodegas.filter(bodega =>
+    bodega.label.toLowerCase().includes(filtroBodega.toLowerCase())
+  );
+
+  const selectedCaja = watch('caja');
+  const selectedBodega = watch('bodega');
+
+  useEffect(() => {
+    if (selectedCaja) {
+      localStorage.setItem('defaultCaja', selectedCaja);
+    }
+  }, [selectedCaja]);
+
+  useEffect(() => {
+    if (selectedBodega) {
+      localStorage.setItem('defaultBodega', selectedBodega);
+    }
+  }, [selectedBodega]);
 
   const onSubmit = (data) => {
     console.log('Ingresando a la caja:', data);
@@ -29,14 +73,48 @@ const FormularioAdmision = () => {
           <Row className="mb-3">
             <Col md={6}>
               <Form.Group>
-                <Form.Label># Caja *</Form.Label>
-                <Form.Control as="select" {...register('caja')}>
+                <Form.Label>Bodega *</Form.Label>
+                <Form.Control
+                  type="text"
+                  placeholder="Filtrar bodegas"
+                  value={filtroBodega}
+                  onChange={(e) => setFiltroBodega(e.target.value)}
+                  className="mb-2"
+                />
+                <Form.Control as="select" {...register('bodega')}>
                   <option value="">Seleccione</option>
-                  <option value="admisiones">Caja Admisiones</option>
+                  {bodegasFiltradas.map((b) => (
+                    <option key={b.value} value={b.value}>
+                      {b.label}
+                    </option>
+                  ))}
                 </Form.Control>
               </Form.Group>
             </Col>
 
+            <Col md={6}>
+              <Form.Group>
+                <Form.Label># Caja *</Form.Label>
+                <Form.Control
+                  type="text"
+                  placeholder="Filtrar cajas"
+                  value={filtroCaja}
+                  onChange={(e) => setFiltroCaja(e.target.value)}
+                  className="mb-2"
+                />
+                <Form.Control as="select" {...register('caja')}>
+                  <option value="">Seleccione</option>
+                  {cajasFiltradas.map((caja) => (
+                    <option key={caja.value} value={caja.value}>
+                      {caja.label}
+                    </option>
+                  ))}
+                </Form.Control>
+              </Form.Group>
+            </Col>
+
+          </Row>
+          <Row className="mb-3">
             <Col md={6}>
               <Form.Group>
                 <Form.Label># Cajero *</Form.Label>
@@ -46,9 +124,7 @@ const FormularioAdmision = () => {
                 </Form.Control>
               </Form.Group>
             </Col>
-          </Row>
 
-          <Row className="mb-3">
             <Col md={6}>
               <Form.Group>
                 <Form.Label>Clave *</Form.Label>


### PR DESCRIPTION
## Summary
- add caja filter list and default selection persistence
- add bodega filter and persistence across sessions

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68761906a7608331b9c449c8c5facf35